### PR TITLE
add debug pprof route attachment options

### DIFF
--- a/examples/simple.go
+++ b/examples/simple.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/dbubel/intake"
-	"github.com/julienschmidt/httprouter"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/dbubel/intake"
+	"github.com/julienschmidt/httprouter"
+	"github.com/sirupsen/logrus"
 )
 
 type test struct {
@@ -44,7 +45,6 @@ func mw2(next intake.Handler) intake.Handler {
 }
 
 func main() {
-
 	apiLogger := logrus.New()
 	apiLogger.SetLevel(logrus.DebugLevel)
 	apiLogger.SetReportCaller(true)
@@ -60,12 +60,14 @@ func main() {
 		intake.GET("/test-get", testSimple),
 	}
 
-	//mw := Middleware{logger: apiLogger}
+	mw := Middleware{logger: apiLogger}
 
-	//app.AddGlobalMiddleware(mw.Logging)
+	app.AddGlobalMiddleware(mw.Logging)
 	app.AddGlobalMiddleware(mw2)
 	app.AddGlobalMiddleware(mw1)
 	app.AddEndpoints(eps)
+
+	app.AttachPprofTraceEndpoints()
 
 	app.Run(&http.Server{
 		Addr:           ":8000",

--- a/trace.go
+++ b/trace.go
@@ -1,0 +1,43 @@
+package intake
+
+import (
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// AttachPprofTraceEndpoints attaches with index page for viewing
+func (a *Intake) AttachPprofTraceEndpoints() {
+	a.Logger.Info("attaching debug pprof endpoints")
+	a.Router.Handler(http.MethodGet, "/debug/pprof/*item", http.DefaultServeMux)
+}
+
+// DebugTraceEndpoints follows the same middleware route pattern without the pprof
+// index page
+func DebugTraceEndpoints(mw ...MiddleWare) Endpoints {
+	endpoints := Endpoints{
+		GET("/debug/pprof/cmdline", DEBUGPProfCmdLine),
+		GET("/debug/pprof/profile", DEBUGPProfProfile),
+		GET("/debug/pprof/symbol", DEBUGPProfSymbol),
+		GET("/debug/pprof/trace", DEBUGPProfTrace),
+	}
+	endpoints.Use(mw...)
+	return endpoints
+}
+
+func DEBUGPProfCmdLine(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	pprof.Cmdline(w, r)
+}
+
+func DEBUGPProfProfile(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	pprof.Profile(w, r)
+}
+
+func DEBUGPProfSymbol(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	pprof.Symbol(w, r)
+}
+
+func DEBUGPProfTrace(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	pprof.Trace(w, r)
+}


### PR DESCRIPTION
- added main router debug pprof attachment option that includes the index html page for viewing
- added intake debug pprof middleware pattern attachment option that follows same patterns but doesn't include index page due to conflicts with httprouter wildcards